### PR TITLE
Spezifizierung JSpO 3.1: Aberkennung halber Punkte

### DIFF
--- a/Jugendspielordnung.md
+++ b/Jugendspielordnung.md
@@ -124,7 +124,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
     1.  Anordnung, den Zuschauerraum zu verlassen,
     1.  Annullierung von Spielergebnissen und Anordnung von Wiederholungsspielen,
     1.  Erkennung auf Verlust von Partien,
-    1.  Aberkennung eines Punktes oder mehrerer Punkte am Ende des Turniers ohne Einflussnahme auf ein Einzelergebnis.
+    1.  Aberkennung eines oder eines halben Punktes oder mehrerer Punkte am Ende des Turniers ohne Einflussnahme auf ein Einzelergebnis.
 
         Bei wiederholten oder groben Verstößen können weiterhin verhängt werden:
     1.  Geldbußen bis zu 100 Euro,


### PR DESCRIPTION
Der Strafenkatalog in JSpO 3.1 soll darin ergänzt werden, dass auch explizit nur halbe Punkte am Ende des Turniers abgezogen werden können.
Da es sich um eine Änderung der JSpO handelt, kann eine entsprechende Änderung erst von der Jugendversammlung 2015 beschlossen werden.
Die Diskussion und Abstimmung im Arbeitskreis Spielbetrieb steht noch aus.